### PR TITLE
[fix] Header 라우팅 오류 해결

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -12,7 +12,7 @@
     <nav class="nav-links">
       <div class="nav-dropdown">
         <div class="nav-link-wrapper" @click="toggleHairMenu">
-          <router-link to="/hair" class="nav-link" @click.prevent>HAIR</router-link>
+          <span class="nav-link">HAIR</span>
           <svg class="dropdown-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" :class="{ 'rotated': showHairMenu }">
             <path d="M6 9L12 15L18 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
@@ -45,7 +45,7 @@
       </div>
       <div class="nav-dropdown">
         <div class="nav-link-wrapper" @click="toggleMakeupMenu">
-          <router-link to="/makeup" class="nav-link" @click.prevent>MAKEUP</router-link>
+          <span class="nav-link">MAKEUP</span>
           <svg class="dropdown-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" :class="{ 'rotated': showMakeupMenu }">
             <path d="M6 9L12 15L18 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
@@ -110,7 +110,7 @@
       </div>
       <div class="look-dropdown">
         <div class="look-link-wrapper" @click="toggleLookMenu">
-          <router-link to="/look" class="look-link" @click.prevent>LOOK</router-link>
+          <span class="look-link">LOOK</span>
           <svg class="dropdown-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" :class="{ 'rotated': showLookMenu }">
             <path d="M6 9L12 15L18 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
@@ -345,7 +345,7 @@ export default {
   background-color: black;
   color: white;
   position: fixed;
-  top: 0;
+  top: 10px;
   left: 0;
   right: 0;
   z-index: 1000;
@@ -604,7 +604,6 @@ export default {
   color: #F05EC9;
 }
 
-/* Remove duplicate triangle styles and keep only one */
 .look-dropdown-content::before {
   content: '';
   position: absolute;


### PR DESCRIPTION
## #️⃣연관된 이슈

close #7 

## 📝작업 내용

<img width="1440" alt="스크린샷 2025-04-13 오후 5 00 38" src="https://github.com/user-attachments/assets/b020faf0-7658-4035-8fa4-9a705adb5ae9" />

헤더에서 카테고리 선택 시 새로운 링크로 라우팅 되는 오류를 해결하고, 기존 화면에서 드롭다운 창으로 뜨게 수정하였습니다. 

