### PR TITLE
[feat] 상단 카테고리별 필터 기능 구현

### DIFF
--- a/src/components/CategoryGrid.vue
+++ b/src/components/CategoryGrid.vue
@@ -1,0 +1,210 @@
+<template>
+    <div class="category-page">
+      <div class="category-icons">
+        <div 
+          v-for="icon in categoryIcons" 
+          :key="icon.id"
+          :class="['icon-item', { active: selectedSubCategory === icon.category }]"
+        >
+          <img :src="icon.imageUrl" :alt="icon.category">
+          <span>{{ icon.category }}</span>
+        </div>
+      </div>
+      <div class="image-grid" ref="grid" @scroll="handleScroll">
+        <template v-for="(post, index) in posts" :key="post.id">
+          <ImageCard
+            v-if="post && post.thumbnailUrl"
+            :imageUrl="post.thumbnailUrl"
+            :showIndex="false"
+          />
+        </template>
+        <div v-if="loading" class="loading">Loading...</div>
+      </div>
+    </div>
+  </template>
+  
+  <script>
+  import ImageCard from './ImageCard.vue'
+  import axios from 'axios'
+  
+  export default {
+    name: 'CategoryGrid',
+    components: {
+      ImageCard
+    },
+    props: {
+      mainCategory: {
+        type: String,
+        required: true
+      },
+      subCategory: {
+        type: String,
+        required: true
+      }
+    },
+    data() {
+      return {
+        posts: [],
+        loading: false,
+        lastPostId: null,
+        hasMore: true,
+        selectedSubCategory: '',
+        categoryIcons: [
+          { id: 1, category: '아우터', imageUrl: '/icons/outer.png' },
+          { id: 2, category: '코트', imageUrl: '/icons/coat.png' },
+          { id: 3, category: '패딩', imageUrl: '/icons/padding.png' },
+          { id: 4, category: '무스탕', imageUrl: '/icons/mustang.png' },
+          { id: 5, category: '가디건', imageUrl: '/icons/cardigan.png' },
+          { id: 6, category: '플리스', imageUrl: '/icons/fleece.png' },
+          { id: 7, category: '자켓', imageUrl: '/icons/jacket.png' },
+          { id: 8, category: '점퍼', imageUrl: '/icons/jumper.png' },
+          { id: 9, category: '기타', imageUrl: '/icons/etc.png' },
+          { id: 10, category: '#TAG', imageUrl: '/icons/tag.png' }
+        ]
+      }
+    },
+    methods: {
+      async fetchPosts() {
+        if (this.loading || !this.hasMore) return;
+        
+        try {
+          this.loading = true;
+          const url = this.lastPostId 
+            ? `/api/post/category/${this.mainCategory}/${this.subCategory}?lastId=${this.lastPostId}`
+            : `/api/post/category/${this.mainCategory}/${this.subCategory}`;
+          
+          console.log('API Request URL:', url);
+          const response = await axios.get(url);
+          console.log('API Response:', response.data);
+          
+          const newPosts = response.data;
+          
+          if (newPosts.length === 0 || newPosts.length < 20) {
+            this.hasMore = false;
+          }
+          
+          if (newPosts.length > 0) {
+            this.lastPostId = newPosts[newPosts.length - 1].id;
+            this.posts = [...this.posts, ...newPosts.filter(post => post && post.thumbnailUrl)];
+          }
+        } catch (error) {
+          console.error('Failed to fetch posts:', error);
+        } finally {
+          this.loading = false;
+        }
+      },
+      handleScroll(e) {
+        const grid = this.$refs.grid;
+        const scrollPosition = grid.scrollTop + grid.clientHeight;
+        const scrollThreshold = grid.scrollHeight - 100;
+        
+        if (scrollPosition >= scrollThreshold && !this.loading) {
+          this.fetchPosts();
+        }
+      }
+    },
+    watch: {
+      subCategory: {
+        immediate: true,
+        handler(newCategory) {
+          this.selectedSubCategory = newCategory;
+          this.posts = [];
+          this.lastPostId = null;
+          this.hasMore = true;
+          this.fetchPosts();
+        }
+      }
+    }
+  }
+  </script>
+  
+  <style scoped>
+  .category-page {
+    padding-top: 20px;
+  }
+  
+  .category-icons {
+    display: flex;
+    gap: 20px;
+    padding: 20px;
+    overflow-x: auto;
+    margin-bottom: 20px;
+    justify-content: center;
+  }
+  
+  .icon-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    padding: 10px;
+    border-radius: 10px;
+    transition: all 0.3s ease;
+  }
+  
+  .icon-item img {
+    width: 50px;
+    height: 50px;
+    object-fit: cover;
+    border-radius: 10px;
+  }
+  
+  .icon-item span {
+    font-size: 12px;
+    color: #666;
+  }
+  
+  .icon-item.active {
+    background-color: rgba(0, 0, 0, 0.1);
+    img {
+      border: 2px solid black;
+    }
+    span {
+      color: black;
+      font-weight: bold;
+    }
+  }
+  
+  .image-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 250px);
+    gap: 20px;
+    padding: 20px 0;
+    justify-content: center;
+    margin: 0 auto;
+    height: calc(100vh - 280px);
+    overflow-y: auto;
+  }
+  
+  .loading {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 20px;
+    color: #666;
+  }
+  
+  @media (max-width: 1400px) {
+    .image-grid {
+      grid-template-columns: repeat(4, 250px);
+    }
+  }
+  
+  @media (max-width: 1100px) {
+    .image-grid {
+      grid-template-columns: repeat(3, 250px);
+    }
+  }
+  
+  @media (max-width: 850px) {
+    .image-grid {
+      grid-template-columns: repeat(2, 250px);
+    }
+  }
+  
+  @media (max-width: 580px) {
+    .image-grid {
+      grid-template-columns: repeat(1, 250px);
+    }
+  }
+  </style> 

--- a/src/components/CategoryLikesGrid.vue
+++ b/src/components/CategoryLikesGrid.vue
@@ -1,0 +1,135 @@
+<template>
+    <div class="image-grid" @scroll="handleScroll">
+      <template v-for="(post, index) in posts" :key="post.id">
+        <ImageCard
+          v-if="post && post.thumbnailUrl"
+          :imageUrl="post.thumbnailUrl"
+          :index="index + 1"
+          :showIndex="true"
+        />
+      </template>
+      <div v-if="loading" class="loading">Loading...</div>
+    </div>
+  </template>
+  
+  <script>
+  import ImageCard from './ImageCard.vue'
+  import axios from 'axios'
+  
+  export default {
+    name: 'CategoryLikesGrid',
+    components: {
+      ImageCard
+    },
+    props: {
+      categoryId: {
+        type: String,
+        required: true
+      }
+    },
+    data() {
+      return {
+        posts: [],
+        loading: false,
+        lastPostId: null,
+        hasMore: true
+      }
+    },
+    methods: {
+      async fetchPosts() {
+        if (this.loading || !this.hasMore) return;
+        
+        try {
+          this.loading = true;
+          let url = `/api/post/feed?sort=likes&categoryIds=${this.categoryId}`;
+          
+          if (this.lastPostId) {
+            url += `&lastPostId=${this.lastPostId}`;
+          }
+          
+          console.log('API Request URL:', url);
+          
+          const response = await axios.get(url);
+          const newPosts = response.data;
+          
+          if (newPosts.length < 20) {
+            this.hasMore = false;
+          }
+          
+          if (newPosts.length > 0) {
+            this.lastPostId = newPosts[newPosts.length - 1].id;
+            this.posts = [...this.posts, ...newPosts];
+          }
+        } catch (error) {
+          console.error('Failed to fetch posts:', error);
+        } finally {
+          this.loading = false;
+        }
+      },
+      handleScroll(e) {
+        const element = e.target;
+        if (element.scrollHeight - element.scrollTop <= element.clientHeight + 100) {
+          this.fetchPosts();
+        }
+      }
+    },
+    created() {
+      this.fetchPosts();
+    },
+    watch: {
+      categoryId: {
+        handler() {
+          this.posts = [];
+          this.lastPostId = null;
+          this.hasMore = true;
+          this.fetchPosts();
+        },
+        immediate: true
+      }
+    }
+  }
+  </script>
+  
+  <style scoped>
+  .image-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 250px);
+    gap: 20px;
+    padding: 20px 0;
+    justify-content: center;
+    margin: 0 auto;
+    height: calc(100vh - 180px);
+    overflow-y: auto;
+  }
+  
+  .loading {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 20px;
+    color: #666;
+  }
+  
+  @media (max-width: 1400px) {
+    .image-grid {
+      grid-template-columns: repeat(4, 250px);
+    }
+  }
+  
+  @media (max-width: 1100px) {
+    .image-grid {
+      grid-template-columns: repeat(3, 250px);
+    }
+  }
+  
+  @media (max-width: 850px) {
+    .image-grid {
+      grid-template-columns: repeat(2, 250px);
+    }
+  }
+  
+  @media (max-width: 580px) {
+    .image-grid {
+      grid-template-columns: repeat(1, 250px);
+    }
+  }
+  </style> 

--- a/src/components/CategoryNewestGrid.vue
+++ b/src/components/CategoryNewestGrid.vue
@@ -1,0 +1,139 @@
+<template>
+    <div class="image-grid" ref="grid" @scroll="handleScroll">
+      <template v-for="(post, index) in posts" :key="post.id">
+        <ImageCard
+          v-if="post && post.thumbnailUrl"
+          :imageUrl="post.thumbnailUrl"
+          :showIndex="false"
+        />
+      </template>
+      <div v-if="loading" class="loading">Loading...</div>
+    </div>
+  </template>
+  
+  <script>
+  import ImageCard from './ImageCard.vue'
+  import axios from 'axios'
+  
+  export default {
+    name: 'CategoryNewestGrid',
+    components: {
+      ImageCard
+    },
+    props: {
+      categoryId: {
+        type: String,
+        required: true
+      }
+    },
+    data() {
+      return {
+        posts: [],
+        loading: false,
+        lastPostId: null,
+        hasMore: true
+      }
+    },
+    methods: {
+      async fetchPosts() {
+        if (this.loading || !this.hasMore) return;
+        
+        try {
+          this.loading = true;
+          let url = `/api/post/feed?sort=latest&categoryIds=${this.categoryId}`;
+          
+          if (this.lastPostId) {
+            url += `&lastPostId=${this.lastPostId}`;
+          }
+          
+          console.log('API Request URL:', url);
+          const response = await axios.get(url);
+          console.log('API Response:', response.data);
+          
+          const newPosts = response.data;
+          
+          if (newPosts.length === 0 || newPosts.length < 20) {
+            this.hasMore = false;
+          }
+          
+          if (newPosts.length > 0) {
+            console.log('Last post in new batch:', newPosts[newPosts.length - 1]);
+            this.lastPostId = newPosts[newPosts.length - 1].id;
+            this.posts = [...this.posts, ...newPosts.filter(post => post && post.thumbnailUrl)];
+          }
+        } catch (error) {
+          console.error('Failed to fetch posts:', error);
+        } finally {
+          this.loading = false;
+        }
+      },
+      handleScroll(e) {
+        const grid = this.$refs.grid;
+        const scrollPosition = grid.scrollTop + grid.clientHeight;
+        const scrollThreshold = grid.scrollHeight - 100;
+        
+        if (scrollPosition >= scrollThreshold && !this.loading) {
+          this.fetchPosts();
+        }
+      }
+    },
+    created() {
+      this.fetchPosts();
+    },
+    watch: {
+      categoryId: {
+        handler() {
+          this.posts = [];
+          this.lastPostId = null;
+          this.hasMore = true;
+          this.fetchPosts();
+        },
+        immediate: true
+      }
+    }
+  }
+  </script>
+  
+  <style scoped>
+  .image-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 250px);
+    gap: 20px;
+    padding: 20px 0;
+    justify-content: center;
+    margin: 0 auto;
+    height: calc(100vh - 180px);
+    overflow-y: auto;
+  }
+  
+  .loading {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 20px;
+    color: #666;
+  }
+  
+  @media (max-width: 1400px) {
+    .image-grid {
+      grid-template-columns: repeat(4, 250px);
+    }
+  }
+  
+  @media (max-width: 1100px) {
+    .image-grid {
+      grid-template-columns: repeat(3, 250px);
+    }
+  }
+  
+  @media (max-width: 850px) {
+    .image-grid {
+      grid-template-columns: repeat(2, 250px);
+    }
+  }
+  
+  @media (max-width: 580px) {
+    .image-grid {
+      grid-template-columns: repeat(1, 250px);
+    }
+  }
+  </style> 

--- a/src/constants/categoryMap.js
+++ b/src/constants/categoryMap.js
@@ -1,0 +1,142 @@
+// 카테고리 ID 매핑
+
+export const categoryMap = {
+    // LOOK ------------------------------------------------------------
+      // 아우터 (11-18)
+      'coat': '11',
+      'padding': '12',
+      'mustang': '13',
+      'cardigan': '14',
+      'fleece': '15',
+      'jacket': '16',
+      'jumper': '17',
+      'etc-outer': '18',
+    
+      // 상의 (19-26)
+      'mantoman': '19',
+      'hood': '20',
+      'knit': '21',
+      'shirt': '22',
+      'long-sleeve': '23',
+      'short-sleeve': '24',
+      'sleeveless': '25',
+      'etc-top': '26',
+    
+      // 하의 (27-34)
+      'denim-pants': '27',
+      'cotton-pants': '28',
+      'cargo-pants': '29',
+      'training-pants': '30',
+      'slacks': '31',
+      'skirt': '32',
+      'shorts': '33',
+      'etc-bottom': '34',
+    
+      // 신발 (35-40)
+      'sneakers': '35',
+      'gudu': '36',
+      'boots': '37',
+      'flat': '38',
+      'slipper': '39',
+      'etc-shoes': '40',
+    
+      // 모자 (41-48)
+      'cap': '41',
+      'hunting': '42',
+      'fedora': '43',
+      'beanie': '44',
+      'trooper': '45',
+      'balaclava': '46',
+      'etc-hat': '48',
+    
+      // 가방 (49-56)
+      'backpack': '49',
+      'shoulder-bag': '50',
+      'cross-bag': '51',
+      'tote-bag': '52',
+      'waist-hip': '53',
+      'eco-bag': '54',
+      'clutch': '55',
+      'etc-bag': '56',
+    
+      // 악세서리 (57-63, 66)
+      'earrings': '57',
+      'necklace': '58',
+      'ring': '59',
+      'bracelet': '60',
+      'watch': '61',
+      'belt': '62',
+      'glasses': '63',
+      'etc-acc': '66',
+    
+    // HAIR ------------------------------------------------------------
+    
+      // 염색 (70-76, 78)
+      'black': '70',
+      'brown': '71',
+      'blonde': '72',
+      'red': '73',
+      'blue': '74',
+      'purple': '75',
+      'pink': '76',
+      'etc-color': '78',
+    
+      // 펌 (79-80)
+      'men-perm': '79',
+      'women-perm': '80',
+    
+      // 커트 (81-82)
+      'men-cut': '81',
+      'women-cut': '82',
+    
+    // MAKEUP ------------------------------------------------------------
+      // 베이스 (118-122)
+      'foundation': '118',    // 파운데이션
+      'bb-cream': '119',     // BB크림
+      'cushion': '120',      // 쿠션
+      'powder': '121',       // 파우더
+      'etc-base': '122',     // 기타
+    
+      // 립 (123-127)
+      'lipstick': '123',     // 립스틱
+      'tint': '124',         // 립틴트
+      'gloss': '125',        // 립글로스
+      'balm': '126',         // 립밤
+      'etc-lip': '127',      // 기타
+    
+      // 아이브로우 (128-136)
+      'eyebrow-pencil': '128',    // 아이브로우 펜슬
+      'eyebrow-powder': '129',    // 아이브로우 파우더
+      'eyebrow-mascara': '130',   // 브로우 마스카라
+      'eyebrow-tint': '131',      // 브로우 틴트
+      'etc-eyebrow': '136',       // 기타
+    
+      // 아이섀도우 (137-140)
+      'matt-shadow': '137',       // 매트 섀도우
+      'shimmer-shadow': '138',    // 쉬머 섀도우
+      'glitter-shadow': '139',    // 글리터 섀도우
+      'etc-shadow': '140',        // 기타
+    
+      // 아이라이너 (141-144)
+      'pencil-liner': '141',      // 펜슬 아이라이너
+      'liquid-liner': '142',      // 리퀴드 아이라이너
+      'etc-liner': '144',         // 기타
+    
+      // 속눈썹 (145-147)
+      'mascara': '145',           // 마스카라
+      'volume': '146',            // 볼륨
+      'etc-lash': '147',          // 기타
+    
+      // 기타 메이크업 (148-154)
+      'highlight': '148',         // 하이라이터
+      'shading': '149',          // 쉐이딩
+      'blusher': '150',          // 블러셔
+      'makeup-review': '151',     // 메이크업 리뷰
+      'makeup-brush': '152',      // 메이크업 브러쉬
+      'makeup-puff': '153',       // 메이크업 퍼프
+      'etc': '154'               // 기타
+    }
+    
+    export function getCategoryId(category) {
+      return categoryMap[category]
+    } 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,10 @@ import ProfileEdit from "../views/ProfileEdit.vue";
 import MainPage from "../views/MainPage.vue";
 import LikesGrid from "../components/LikesGrid.vue";
 import NewestGrid from "../components/NewestGrid.vue";
+import CategoryLikesGrid from "../components/CategoryLikesGrid.vue";
+import CategoryNewestGrid from "../components/CategoryNewestGrid.vue";
+import CategoryGrid from "../components/CategoryGrid.vue";
+import { getCategoryId } from '../constants/categoryMap'
 
 const routes = [
   {
@@ -52,6 +56,78 @@ const routes = [
     name: "StyleShareCreate",
     component: StyleShareCreate,
   },
+  {
+    path: '/look/:category',
+    component: MainPage,
+    children: [
+      {
+        path: '',
+        redirect: to => `/look/${to.params.category}/likes`
+      },
+      {
+        path: 'likes',
+        name: 'CategoryLikes',
+        component: CategoryLikesGrid,
+        props: route => ({ categoryId: getCategoryId(route.params.category) })
+      },
+      {
+        path: 'latest',
+        name: 'CategoryNewest',
+        component: CategoryNewestGrid,
+        props: route => ({ categoryId: getCategoryId(route.params.category) })
+      }
+    ]
+  },
+  {
+    path: '/hair/:category',
+    component: MainPage,
+    children: [
+      {
+        path: '',
+        redirect: to => `/hair/${to.params.category}/likes`
+      },
+      {
+        path: 'likes',
+        name: 'HairLikes',
+        component: CategoryLikesGrid,
+        props: route => ({ categoryId: getCategoryId(route.params.category) })
+      },
+      {
+        path: 'latest',
+        name: 'HairNewest',
+        component: CategoryNewestGrid,
+        props: route => ({ categoryId: getCategoryId(route.params.category) })
+      }
+    ]
+  },
+  {
+    path: '/makeup/:category',
+    component: MainPage,
+    children: [
+      {
+        path: '',
+        redirect: to => `/makeup/${to.params.category}/likes`
+      },
+      {
+        path: 'likes',
+        name: 'MakeupLikes',
+        component: CategoryLikesGrid,
+        props: route => ({ categoryId: getCategoryId(route.params.category) })
+      },
+      {
+        path: 'latest',
+        name: 'MakeupNewest',
+        component: CategoryNewestGrid,
+        props: route => ({ categoryId: getCategoryId(route.params.category) })
+      }
+    ]
+  },
+  {
+    path: '/category/:mainCategory/:subCategory',
+    name: 'Category',
+    component: CategoryGrid,
+    props: true
+  }
 ];
 
 const router = createRouter({


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #19 

## 📝작업 내용

> HAIR, MAKEUP, LOOK 토글 누른 후 카테고리 선택하였을 때, 필터 기능 적용된 상태로 게시물 조회할 수 있게 구현했습니다.
각 카테고리 선택 시 기본 좋아요 순으로 보임. (LIKES 버튼 눌려있는 상태)

### 스크린샷 

> HAIR
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/09728411-2558-4f68-a6c5-aa15e7ca576b" />

-----------
> LOOK
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/6319bafd-104a-4990-adc1-60a574acf90b" />

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/a48d50c8-cb07-4852-bc49-88104135498a" />

## 💬리뷰 요구사항
MAKEUP 카테고리는 현재 DB에 더미데이터가 들어있지 않아, HAIR 와 LOOK 하위 카테고리로 체크해주시면 됩니다 !

